### PR TITLE
feat: chevron 토글 구현, 약관 동의에 적용

### DIFF
--- a/src/components/SignUpPage/TermsAgreement/TermsAgreement.tsx
+++ b/src/components/SignUpPage/TermsAgreement/TermsAgreement.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import CheckBoxInput from '~/components/common/CheckBoxInput/CheckBoxInput';
+import { ChevronToggle } from '~/components/common/ChevronToggle';
 import { ThemeButton } from '~/components/common/ThemeButton';
 import { SignUpTermsAgreement } from '~/types/apis/signUp';
 import { SignUpHeader } from '../SignUpHeader';
@@ -43,24 +44,36 @@ export default function TermsAgreement({ onNext }: TermsAgreementProps) {
           />
         </HeaderCheckBoxContainer>
         <BorderBox>
-          <CheckBoxInput
-            onChange={(e) => {
-              setMandatoryUsageChecked(e.target.checked);
-            }}
-            id="mandatory-usage"
-            text="[필수] 이용약관 동의"
-            isChecked={mandatoryUsageChecked}
-          />
+          {/*TODO - 약관 내용 토글의 children으로 작성하기 */}
+          <ChevronToggle
+            label={
+              <CheckBoxInput
+                onChange={(e) => {
+                  setMandatoryUsageChecked(e.target.checked);
+                }}
+                id="mandatory-usage"
+                text="[필수] 이용약관 동의"
+                isChecked={mandatoryUsageChecked}
+              />
+            }
+            fontSize={'large'}
+          ></ChevronToggle>
         </BorderBox>
         <BorderBox>
-          <CheckBoxInput
-            onChange={(e) => {
-              setMandatoryPersonalChecked(e.target.checked);
-            }}
-            id="mandatory-personal"
-            text="[필수] 개인정보 수집 및 이용 동의"
-            isChecked={mandatoryPersonalChecked}
-          />
+          {/*TODO - 약관 내용 토글의 children으로 작성하기 */}
+          <ChevronToggle
+            label={
+              <CheckBoxInput
+                onChange={(e) => {
+                  setMandatoryPersonalChecked(e.target.checked);
+                }}
+                id="mandatory-personal"
+                text="[필수] 개인정보 수집 및 이용 동의"
+                isChecked={mandatoryPersonalChecked}
+              />
+            }
+            fontSize={'large'}
+          ></ChevronToggle>
         </BorderBox>
       </FormItem>
       <FormItem>

--- a/src/components/common/ChevronToggle/ChevronToggle.tsx
+++ b/src/components/common/ChevronToggle/ChevronToggle.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { GoChevronDown, GoChevronUp } from 'react-icons/go';
+import styled from 'styled-components';
+import theme from '~/styles/theme';
+
+interface ChevronToggleProps {
+  label: React.ReactNode;
+  children?: React.ReactNode;
+  width?: string;
+  fontSize?: keyof typeof theme.fontSize;
+  fontColor?: string;
+  iconColor?: string;
+}
+
+export default function ChevronToggle({
+  label,
+  children,
+  width = '100%',
+  fontSize = 'medium',
+  fontColor = theme.colors.gray['900'],
+  iconColor = theme.colors.gray['400'],
+}: ChevronToggleProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleToggleClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+  return (
+    <Container width={width}>
+      <LabelToggleWrap>
+        <Label
+          fontSize={fontSize}
+          color={fontColor}
+        >
+          {label}
+        </Label>
+        {!isOpen ? (
+          <GoChevronDown
+            onClick={handleToggleClick}
+            size={theme.fontSize[fontSize]}
+            color={iconColor}
+          />
+        ) : (
+          <GoChevronUp
+            onClick={handleToggleClick}
+            size={theme.fontSize[fontSize]}
+            color={iconColor}
+          />
+        )}
+      </LabelToggleWrap>
+      {isOpen && <ContentsWrap>{children}</ContentsWrap>}
+    </Container>
+  );
+}
+
+const Container = styled.div<Pick<ChevronToggleProps, 'width'>>`
+  width: ${({ width }) => width!};
+`;
+
+const LabelToggleWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Label = styled.div<Pick<ChevronToggleProps, 'fontSize' | 'fontColor'>>`
+  font-size: ${({ theme, fontSize }) => theme.fontSize[fontSize!]};
+  color: ${({ fontColor }) => fontColor};
+`;
+
+const ContentsWrap = styled.div`
+  margin-top: 1.5rem;
+`;

--- a/src/components/common/ChevronToggle/index.ts
+++ b/src/components/common/ChevronToggle/index.ts
@@ -1,0 +1,3 @@
+import ChevronToggle from './ChevronToggle';
+
+export { ChevronToggle };


### PR DESCRIPTION
<img width="542" alt="스크린샷 2024-02-16 오전 11 46 50" src="https://github.com/neuroflowNininini/nininini-FE/assets/91667853/acae462b-bba1-49b7-b66b-d35ec88c8a30">

### ChevronToggle
- label에 토글 제목
  - 위 이미지처럼 라벨에 단순 텍스트가 아닌 컴포넌트가 통째로 들어갈 수 있기 때문에 타입은 React.ReactNode
- children으로 토글 내부 내용
- 기타 width, fontSize, fontColor, iconColor로 커스텀 스타일