### PR TITLE
fix: 카테고리 그리드 text overflow 해결

### DIFF
--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -20,7 +20,6 @@ const Layout = styled.div``;
 const Container = styled.div`
   margin-top: 5rem;
   max-width: none;
-  padding: 0 2rem;
   ${media.md`
     max-width: ${deviceSizes.xl}px;
     margin: 0 auto;

--- a/src/pages/CategoryPage/CategoryPage.tsx
+++ b/src/pages/CategoryPage/CategoryPage.tsx
@@ -30,15 +30,15 @@ export default function CategoryPage({ category }: CategoryPageProps) {
 
 const ProductListWrap = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(1rem, auto));
   padding: 0 1.5rem;
   column-gap: 2rem;
   ${media.md`
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(1rem, auto));
     padding: 0 3rem;
   `}
   ${media.lg`
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(1rem, auto));
     padding: 0 2rem;
     column-gap: 3rem;
   `}

--- a/src/shared/dummy.js
+++ b/src/shared/dummy.js
@@ -329,7 +329,7 @@ export const bestDummy = [
     id: 'naile',
 
     review: 0,
-    name: '시럽 글리터 프렌치 네일',
+    name: '시럽 글리터 프렌치 네일인데 말이죠 이게 길어지면요 어떻게 되냐면요',
     cost: '12,900',
   },
   {


### PR DESCRIPTION
## 기존  
<img width="398" alt="스크린샷 2024-02-27 오후 5 12 08" src="https://github.com/neuroflowNininini/nininini-FE/assets/91667853/ba655e3e-da5a-4b4d-a347-d62baf64e270">
(제목 텍스트가 길어질 경우 박스 크기가 함께 커지는 문제)

## 수정 후
<img width="404" alt="스크린샷 2024-02-27 오후 5 12 53" src="https://github.com/neuroflowNininini/nininini-FE/assets/91667853/92c524da-51af-4829-b343-d657e3e76aa7">
