### PR TITLE
feature: 소셜 로그인

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import { paths } from './config/paths';
 import { DefaultLayout, FocusLayout, HomeLayout } from './components/layouts';
 import { FixedButtonsGroup } from './components/common/FixedButtonsGroup';
 import { LoginPage } from './pages/LoginPage';
+import { OAuthRedirectPage } from './pages/OAuthRedirectPage';
 import { AuthProvider } from './lib/contexts/AuthProvider';
 import GuestRoute from './routes/GuestRoute';
 import { TermsDetailPage } from './pages/TermsDetailPage';
@@ -59,6 +60,7 @@ const router = createBrowserRouter([
           { path: 'etc', element: <CategoryPage category={'etc'} /> },
         ],
       },
+      { path: paths.oAuthRedirect(), element: <OAuthRedirectPage /> },
     ],
   },
   { path: '*', element: <Root /> },

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -4,6 +4,7 @@ import { paths } from '~/config/paths';
 import { CONSTANTS } from '~/constants';
 import { NinininiErrorResponse } from '~/types/apiResponse';
 import { Login } from '~/types/apis/login';
+import { OAuthPlatform } from '~/types/oAuth';
 import { deleteCookie, getCookie, setCookie } from '~/utils/cookie';
 
 export const postLogin = async (body: Login) => {
@@ -70,4 +71,18 @@ export const postReIssueAccessToken = async () => {
       }
     }
   }
+};
+
+export const postOAuthLogin = async ({
+  platform,
+  onSuccess,
+  code,
+}: {
+  platform: OAuthPlatform;
+  onSuccess: (userId?: string) => void;
+  code: string;
+}) => {
+  const { data } = await NinininiAxios.get(`/api/oauth/${platform}?code=${code}`);
+  onSuccess(data.userId);
+  return data;
 };

--- a/src/api/signUp.ts
+++ b/src/api/signUp.ts
@@ -6,29 +6,14 @@ import { SignUp } from '~/types/apis/signUp';
 
 export const postSignUp = async ({
   body,
-  onDuplicate,
   onSuccess,
 }: {
   body: SignUp;
-  onDuplicate: () => void;
   onSuccess: (data: LoginRes) => void;
 }) => {
-  try {
-    const { data } = await NinininiAxios.post(`/api/members/signup`, body);
-    onSuccess(data);
-    return;
-  } catch (e) {
-    if (isAxiosError<NinininiErrorResponse>(e) && e.response) {
-      const status = e.response.status;
-      switch (status) {
-        case 409:
-          if (e.response.data.exception.errorCode === 'DUP_SIGNUP') {
-            onDuplicate();
-          }
-          break;
-      }
-    }
-  }
+  const { data } = await NinininiAxios.post(`/api/members/signup`, body);
+  onSuccess(data);
+  return;
 };
 
 export const postCheckDuplicateId = async ({
@@ -54,4 +39,16 @@ export const postCheckDuplicateId = async ({
       }
     }
   }
+};
+
+export const postOAuthSignUp = async ({
+  body,
+  onSuccess,
+}: {
+  body: SignUp;
+  onSuccess: (data: LoginRes) => void;
+}) => {
+  const { data } = await NinininiAxios.post(`/api/members/sns`, body);
+  onSuccess(data);
+  return;
 };

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -53,6 +53,12 @@ NinininiAxios.interceptors.response.use(
             throw Error(e);
           }
         }
+        break;
+      case 409:
+        if (errorCode === 'DUP_SIGNUP') {
+          alert('이미 가입된 회원입니다.');
+        }
+        break;
     }
 
     return Promise.reject(error);

--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -1,5 +1,7 @@
 export const ENVIRONMENTS = {
   baseUrl: () => getEnv('REACT_APP_API_BASE_URL'),
+  kakaoRestApiKey: () => getEnv('REACT_APP_OAUTH_KAKAO_REST_API_KEY'),
+  kakaoRedirectUri: () => getEnv('REACT_APP_OAUTH_KAKAO_REDIRECT_URI'),
 };
 
 const getEnv = (key: string) => {

--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -2,6 +2,8 @@ export const ENVIRONMENTS = {
   baseUrl: () => getEnv('REACT_APP_API_BASE_URL'),
   kakaoRestApiKey: () => getEnv('REACT_APP_OAUTH_KAKAO_REST_API_KEY'),
   kakaoRedirectUri: () => getEnv('REACT_APP_OAUTH_KAKAO_REDIRECT_URI'),
+  naverClientId: () => getEnv('REACT_APP_OAUTH_NAVER_CLIENT_ID'),
+  naverRedirectUri: () => getEnv('REACT_APP_OAUTH_NAVER_REDIRECT_URI'),
 };
 
 const getEnv = (key: string) => {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,4 +1,5 @@
 import { Category } from '~/types/category';
+import { SignUpStep } from '~/types/signUp';
 
 export const paths = {
   home: () => `/`,
@@ -9,7 +10,7 @@ export const paths = {
   faq: () => `/faq`,
   myPage: () => `/mypage`,
   cart: () => `/cart`,
-  signUp: () => `/sign-up`,
+  signUp: (step?: SignUpStep) => `/sign-up${step ? `?step=${step}` : ''}`,
   logIn: () => `/login`,
   oAuthRedirect: () => `/oauth/:platform`,
 };

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -11,4 +11,5 @@ export const paths = {
   cart: () => `/cart`,
   signUp: () => `/sign-up`,
   logIn: () => `/login`,
+  oAuthRedirect: () => `/oauth/:platform`,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,4 +4,5 @@ export const CONSTANTS = {
   ACCESS_TOKEN_KEY: 'nininini_access_token',
   REFRESH_TOKEN_KEY: 'nininini_refresh_token',
   KAKAO_SIGNIN_URL: `https://kauth.kakao.com/oauth/authorize?client_id=${ENVIRONMENTS.kakaoRestApiKey()}&redirect_uri=${ENVIRONMENTS.kakaoRedirectUri()}&response_type=code`,
+  NAVER_SIGNIN_URL: `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${ENVIRONMENTS.naverClientId()}&state=test&redirect_uri=${ENVIRONMENTS.naverRedirectUri()}`,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,7 @@ import { ENVIRONMENTS } from '~/config/environments';
 export const CONSTANTS = {
   ACCESS_TOKEN_KEY: 'nininini_access_token',
   REFRESH_TOKEN_KEY: 'nininini_refresh_token',
+  SNS_KEY: 'sns_temp_string',
   KAKAO_SIGNIN_URL: `https://kauth.kakao.com/oauth/authorize?client_id=${ENVIRONMENTS.kakaoRestApiKey()}&redirect_uri=${ENVIRONMENTS.kakaoRedirectUri()}&response_type=code`,
   NAVER_SIGNIN_URL: `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${ENVIRONMENTS.naverClientId()}&state=test&redirect_uri=${ENVIRONMENTS.naverRedirectUri()}`,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,7 @@
+import { ENVIRONMENTS } from '~/config/environments';
+
 export const CONSTANTS = {
   ACCESS_TOKEN_KEY: 'nininini_access_token',
   REFRESH_TOKEN_KEY: 'nininini_refresh_token',
+  KAKAO_SIGNIN_URL: `https://kauth.kakao.com/oauth/authorize?client_id=${ENVIRONMENTS.kakaoRestApiKey()}&redirect_uri=${ENVIRONMENTS.kakaoRedirectUri()}&response_type=code`,
 };

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -73,7 +73,11 @@ export default function LoginPage() {
         <Icon src={appleIcon} />
         <span>Apple로 로그인</span>
       </AppleButton>
-      <NaverButton>
+      <NaverButton
+        onClick={() => {
+          window.location.href = CONSTANTS.NAVER_SIGNIN_URL;
+        }}
+      >
         <Icon src={naverIcon} />
         <span>네이버 로그인</span>
       </NaverButton>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -6,6 +6,7 @@ import Divider from '~/components/common/Divider';
 import { Heading } from '~/components/common/Heading';
 import { Input } from '~/components/common/Input';
 import { paths } from '~/config/paths';
+import { CONSTANTS } from '~/constants';
 import appleIcon from '~/shared/login_icons/icon_apple.png';
 import kakaoIcon from '~/shared/login_icons/kakao.png';
 import naverIcon from '~/shared/login_icons/naver.svg';
@@ -60,7 +61,11 @@ export default function LoginPage() {
         <TextButton>비밀번호 찾기</TextButton>
       </TextButtonsWrap>
       <Divider color={theme.colors.gray[200]} />
-      <KakaoButton>
+      <KakaoButton
+        onClick={() => {
+          window.location.href = CONSTANTS.KAKAO_SIGNIN_URL;
+        }}
+      >
         <Icon src={kakaoIcon} />
         <span>카카오로 3초만에 시작하기</span>
       </KakaoButton>

--- a/src/pages/OAuthRedirectPage/OAuthRedirectPage.tsx
+++ b/src/pages/OAuthRedirectPage/OAuthRedirectPage.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { paths } from '~/config/paths';
+import { OAuthPlatform } from '~/types/oAuth';
+
+export default function OAuthRedirectPage() {
+  const navigate = useNavigate();
+  const { platform } = useParams<{ platform: OAuthPlatform }>();
+  const [params] = useSearchParams();
+  const code = params.get('code');
+
+  // const setCacheKey = useCacheKeyStore((state) => state.setCacheKey);
+
+  const signInCallback = () => {
+    /*NOTE -  새로운 사용자가 로그인한 경우 */
+    /*NOTE - 기존 사용자가 로그인한 경우 */
+    navigate(paths.home());
+    return;
+  };
+
+  useEffect(() => {
+    if (!code) {
+      alert('소셜 서비스와 연결 중 문제가 일어났습니다.\n다시 시도해주세요.');
+      navigate(paths.logIn());
+      return;
+    }
+  }, []);
+
+  return;
+}

--- a/src/pages/OAuthRedirectPage/OAuthRedirectPage.tsx
+++ b/src/pages/OAuthRedirectPage/OAuthRedirectPage.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { postOAuthLogin } from '~/api/login';
 import { paths } from '~/config/paths';
+import { CONSTANTS } from '~/constants';
 import { OAuthPlatform } from '~/types/oAuth';
+import { setCookie } from '~/utils/cookie';
 
 export default function OAuthRedirectPage() {
   const navigate = useNavigate();
@@ -9,14 +12,23 @@ export default function OAuthRedirectPage() {
   const [params] = useSearchParams();
   const code = params.get('code');
 
-  // const setCacheKey = useCacheKeyStore((state) => state.setCacheKey);
+  if (!platform || !code) return;
 
-  const signInCallback = () => {
-    /*NOTE -  새로운 사용자가 로그인한 경우 */
-    /*NOTE - 기존 사용자가 로그인한 경우 */
-    navigate(paths.home());
+  const onSuccess = (userId?: string) => {
+    if (userId) {
+      /*NOTE -  새로운 사용자가 로그인한 경우 */
+      setCookie(CONSTANTS.SNS_KEY, userId);
+      navigate(paths.signUp('interestTags'));
+    } else {
+      /*NOTE - 기존 사용자가 로그인한 경우 */
+      navigate(paths.home());
+    }
     return;
   };
+
+  useEffect(() => {
+    postOAuthLogin({ platform, code, onSuccess });
+  }, []);
 
   useEffect(() => {
     if (!code) {

--- a/src/pages/OAuthRedirectPage/index.ts
+++ b/src/pages/OAuthRedirectPage/index.ts
@@ -1,0 +1,3 @@
+import OAuthRedirectPage from './OAuthRedirectPage';
+
+export { OAuthRedirectPage };

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { postSignUp } from '~/api/signUp';
 import { BasicInfo } from '~/components/SignUpPage/BasicInfo';
 import { InterestTags } from '~/components/SignUpPage/InterestTags';
@@ -12,14 +13,14 @@ import { LoginRes } from '~/types/apis/login';
 import { SignUp } from '~/types/apis/signUp';
 import { setCookie } from '~/utils/cookie';
 
-type Step = 'agreement' | 'basicInfo' | 'interestTags' | 'nailRegister' | 'complete';
-
 export default function SignUpPage() {
-  const [step, setStep] = useState<Step>('agreement');
+  const [searchParams] = useSearchParams();
+  const step = searchParams.get('step');
+  const navigate = useNavigate();
   const [signUpData, setSignUpData] = useState<SignUp>();
   return (
     <>
-      {step === 'agreement' && (
+      {step === null && (
         <TermsAgreement
           onNext={({ agreeSms, agreeEmail }) => {
             setSignUpData((prev: SignUp) => ({
@@ -27,7 +28,7 @@ export default function SignUpPage() {
               agreeSms,
               agreeEmail,
             }));
-            setStep('basicInfo');
+            navigate(paths.signUp('basicInfo'));
           }}
         />
       )}
@@ -35,14 +36,14 @@ export default function SignUpPage() {
         <BasicInfo
           onNext={(basicInfo) => {
             setSignUpData((prev: SignUp) => ({ ...prev, ...basicInfo }));
-            setStep('interestTags');
+            navigate(paths.signUp('interestTags'));
           }}
         />
       )}
       {step === 'interestTags' && (
         <InterestTags
           onNext={(data) => {
-            setStep('nailRegister');
+            navigate(paths.signUp('nailRegister'));
             if (!data) return;
             setSignUpData((prev: SignUp) => ({ ...prev, tags: data.tags }));
           }}
@@ -54,13 +55,10 @@ export default function SignUpPage() {
             if (!signUpData) return;
             postSignUp({
               body: aiMeasure ? { ...signUpData, aiMeasure } : signUpData,
-              onDuplicate: () => {
-                alert('이미 가입한 회원입니다.');
-              },
               onSuccess: (data: LoginRes) => {
                 setCookie(CONSTANTS.ACCESS_TOKEN_KEY, data.accessToken);
                 setCookie(CONSTANTS.REFRESH_TOKEN_KEY, data.refreshToken);
-                window.location.href = paths.home();
+                navigate(paths.signUp('complete'));
               },
             });
           }}

--- a/src/types/apis/signUp.ts
+++ b/src/types/apis/signUp.ts
@@ -1,17 +1,17 @@
 import { ReadAiMeasure } from './aiMeasure';
 
 export type SignUpTermsAgreement = {
-  agreeSms: boolean;
-  agreeEmail: boolean;
+  agreeSms?: boolean;
+  agreeEmail?: boolean;
 };
 
 export type SignUpBasicInfo = {
   userId: string;
-  userPw: string;
-  name: string;
-  phoneNumber: string;
-  email: string;
-  birthSex: string;
+  userPw?: string;
+  name?: string;
+  phoneNumber?: string;
+  email?: string;
+  birthSex?: string;
 };
 
 export type SignUpInterestTags = {

--- a/src/types/oAuth.ts
+++ b/src/types/oAuth.ts
@@ -1,0 +1,1 @@
+export type OAuthPlatform = 'kakao' | 'naver' | 'apple';

--- a/src/types/signUp.ts
+++ b/src/types/signUp.ts
@@ -1,0 +1,1 @@
+export type SignUpStep = 'agreement' | 'basicInfo' | 'interestTags' | 'nailRegister' | 'complete';


### PR DESCRIPTION
## 변경사항
- 회원가입 페이지 단계들을 쿼리 스트링 (`step`)에 담음 (소셜 회원가입 후 관심 태그 단계로 바로 이동하기 위함)
(기존: 하나의 url을 공유, step을 useState상태로 관리)

## 소셜 로그인/회원가입 구현 내용
- 신규 사용자가 소셜 로그인한 경우
  - 회원가입 페이지 중 `interestTags` 관심 태그 선택 페이지로 이동, 이때부터 일반회원가입과 동일하게 실행
- 기존 사용자가 소셜 로그인한 경우
  - 일반 로그인과 같이 홈 페이지로 이동